### PR TITLE
fix incorrect relative path when dealing with multiple files having different paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ module.exports = function(options){
 }
 
 function transform(options) {
-  options = options || {}
   return function(file, enc, cb){
     var contents
     var transformed
+    var options = options || {}
     if(file.isStream()) {
       return cb(
         new PluginError("gulp-cssnext", "streaming not supported")

--- a/test/cssnext.js
+++ b/test/cssnext.js
@@ -67,3 +67,46 @@ tape("throws on cssnext error", function(test){
   })
   stream.end(file)
 })
+
+tape("Resolves relative paths for consecutive files in different paths", function(test) {
+  var stream = cssnext()
+  var file = new gutil.File({
+    base: "./fixtures/",
+    path: "./fixtures/import.css",
+    contents: new Buffer(
+      fs.readFileSync(
+        path.resolve(__dirname, "./fixtures/import.css"),
+        "utf8"
+      )
+    )
+  })
+  stream.write(file)
+
+  var file2 = new gutil.File({
+    base : "./fixtures/import/",
+    path : "./fixtures/import/index.css",
+    contents : new Buffer(
+      fs.readFileSync(
+        path.resolve(__dirname, "./fixtures/import/index.css"),
+        "utf8"
+      )
+    )
+  })
+  stream.write(file2)
+
+  var count = 0;
+  stream.on("data", function(file){
+
+    test.equal(
+      file.contents.toString(),
+      fs.readFileSync(
+        path.resolve(__dirname, "./expected/index.css"),
+        "utf8"
+      )
+    )
+    ++count
+    if(count == 2) {
+      test.end()
+    }
+  })
+})

--- a/test/fixtures/import.css
+++ b/test/fixtures/import.css
@@ -1,0 +1,1 @@
+@import './index.css';

--- a/test/fixtures/import/index.css
+++ b/test/fixtures/import/index.css
@@ -1,0 +1,1 @@
+@import '../index.css';


### PR DESCRIPTION
when running with no options, the first file's path is set on options and then propagated to subsequent files, which causes files with different paths to be processed with the incorrect path.

i.e. say we process 'index.css' and 'foo/bar.css' (in that order).
index.css will be processed relative to its path
foo/bar.css will be processed with index.css's path
the error is evident if foo/bar.css includes an import statements, which will be resolved relative to index.css rather than foo/bar.css

an issue remains if/when a user passes in any options, as the current code's options still take precedence over the current file's path, but that seemed to be the intent of the code, so it was left as is.