### PR TITLE
update cssnext options link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gulp.task("stylesheets", function() {
 
 ### Options
 
-Options are directly passed to cssnext, so checkout [cssnext options](https://github.com/cssnext/cssnext#nodejs-options) directly.
+Options are directly passed to cssnext, so checkout [cssnext options](http://cssnext.io/usage/) directly.
 
 _Note: `from` option is by default automatically specified using gulp source._
 


### PR DESCRIPTION
Hi!

There's no documentation of options on https://github.com/cssnext/cssnext#nodejs-options.
So how about this I fixed?