### PR TITLE
Don't mutate options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 var through = require("through2")
 var cssnext = require("cssnext")
 var gutil = require("gulp-util")
+var xtend = require("xtend")
 var PluginError = gutil.PluginError
 
 function transform(opts) {
   return function(file, enc, cb) {
     var contents
     var transformed
-    var options = opts || {}
+    var options = xtend(opts || {})
     if (file.isStream()) {
       return cb(
         new PluginError("gulp-cssnext", "streaming not supported")

--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 var through = require("through2")
 var cssnext = require("cssnext")
 var gutil = require("gulp-util")
-var xtend = require("xtend")
+var objectAssign = require("object-assign")
 var PluginError = gutil.PluginError
 
 function transform(opts) {
   return function(file, enc, cb) {
     var contents
     var transformed
-    var options = xtend(opts || {})
+    var options = objectAssign({}, opts)
     if (file.isStream()) {
       return cb(
         new PluginError("gulp-cssnext", "streaming not supported")

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "cssnext": "^1.0.0",
     "gulp-util": "^3.0.0",
-    "through2": "^0.6.1",
-    "xtend": "~4.0.1"
+    "object-assign": "~4.0.1",
+    "through2": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "cssnext": "^1.0.0",
     "gulp-util": "^3.0.0",
-    "through2": "^0.6.1"
+    "through2": "^0.6.1",
+    "xtend": "~4.0.1"
   },
   "devDependencies": {
     "eslint": "^0.22.1",

--- a/test/cssnext.js
+++ b/test/cssnext.js
@@ -1,31 +1,25 @@
 var tape = require("tape")
 var gutil = require("gulp-util")
+var through2 = require("through2")
 var cssnext = require("..")
 
 var fs = require("fs")
 var path = require("path")
+
+function read(file, encoding) {
+  return fs.readFileSync(path.resolve(__dirname, file), encoding)
+}
 
 tape("cssnext", function(test) {
   var stream = cssnext()
   var file = new gutil.File({
     base: ".",
     path: ".",
-    contents: new Buffer(
-      fs.readFileSync(
-        path.resolve(__dirname, "fixtures/index.css"),
-        {encoding: "utf8"}
-      )
-    ),
+    contents: read("fixtures/index.css"),
   })
 
   stream.on("data", function(data) {
-    test.equal(
-      data.contents.toString(),
-      fs.readFileSync(
-        path.resolve(__dirname, "expected/index.css"),
-        {encoding: "utf8"}
-      )
-    )
+    test.equal(data.contents.toString(), read("expected/index.css", "utf8"))
     test.end()
   })
   stream.end(file)
@@ -36,10 +30,7 @@ tape("cssnext throws if stream", function(test) {
   var file = new gutil.File({
     base: ".",
     path: ".",
-    contents: fs.createReadStream(
-      path.resolve(__dirname, "fixtures/index.css"),
-      {encoding: "utf8"}
-    ),
+    contents: through2(),
   })
   stream.on("error", function(err) {
     test.equal(err.message, "streaming not supported")
@@ -72,45 +63,33 @@ tape("throws on cssnext error", function(test) {
 tape(
   "Resolves relative paths for consecutive files in different paths",
   function(test) {
-    var stream = cssnext()
-    var file = new gutil.File({
-      base: "./test/fixtures/",
-      path: "./test/fixtures/import.css",
-      contents: new Buffer(
-        fs.readFileSync(
-          path.resolve(__dirname, "fixtures/import.css"),
-          {encoding: "utf8"}
-        )
-      ),
-    })
-    stream.write(file)
+    test.plan(4)
 
-    var file2 = new gutil.File({
-      base: "./test/fixtures/import/",
-      path: "./test/fixtures/import/index.css",
-      contents: new Buffer(
-        fs.readFileSync(
-          path.resolve(__dirname, "fixtures/import/index.css"),
-          {encoding: "utf8"}
-        )
-      ),
-    })
-    stream.write(file2)
+    function testTwoFiles(options) {
+      var stream = cssnext(options)
 
-    var count = 0
-    stream.on("data", function(data) {
+      var file1 = new gutil.File({
+        base: "./test/fixtures/",
+        path: "./test/fixtures/import.css",
+        contents: read("fixtures/import.css"),
+      })
 
-      test.equal(
-        data.contents.toString(),
-        fs.readFileSync(
-          path.resolve(__dirname, "expected/index.css"),
-          {encoding: "utf8"}
-        )
-      )
-      ++count
-      if (count === 2) {
-        test.end()
-      }
-    })
+      var file2 = new gutil.File({
+        base: "./test/fixtures/import/",
+        path: "./test/fixtures/import/index.css",
+        contents: read("fixtures/import/index.css"),
+      })
+
+      stream.on("data", function(data) {
+        var expected = read("expected/index.css", "utf8")
+        test.equal(data.contents.toString(), expected)
+      })
+
+      stream.write(file1)
+      stream.end(file2)
+    }
+
+    testTwoFiles()
+    testTwoFiles({})
   }
 )


### PR DESCRIPTION
PR #5 was meant to fix options being mutated between files, but only works when no options are passed. This PR creates a copy of the options for every entry. 

Additionally, I did a small cleanup of the tests for readability. For example, in this

``` js
new Buffer(fs.readFileSync(
    path.resolve(__dirname, "fixtures/index.css"),
    {encoding: "utf8"}
))
```

you can:
- Shorten `{encoding: "utf8"}` to `"utf8"`
- Or even leave it out, you want a buffer anyway
- And because this snippet is used multiple times, I made a helper function:

``` js
function read(file, encoding) {
  return fs.readFileSync(path.resolve(__dirname, file), encoding)
}
```
